### PR TITLE
fix process_tex.py path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To process LaTeX, all files must be in a zip file, similar to the `*.gz` files y
 A few examples are available under `tests/latex/`. For example, you can try:
 
 ```console
-python doc2json/grobid2json/process_tex.py -i test/latex/1911.02782.gz -t temp_dir/ -o output_dir/
+python doc2json/tex2json/process_tex.py -i test/latex/1911.02782.gz -t temp_dir/ -o output_dir/
 ```
 
 Again, this will produce a JSON file in the specified `output_dir`.


### PR DESCRIPTION
I think there's a possibly confusing typo in the README, here's a proposed fix