### PR TITLE
Downgrade itsdangerous version

### DIFF
--- a/doc2json/flask/app.py
+++ b/doc2json/flask/app.py
@@ -53,6 +53,16 @@ def upload_file():
 
     return redirect(url_for('index'))
 
+@app.route('/upload_url')
+def upload_url():
+    url = request.args.get('url')
+    filename = "unknown"
+    pdf_content = requests.get(url).content
+    # compute hash
+    pdf_sha = hashlib.sha1(pdf_content).hexdigest()
+    # get results
+    results = process_pdf_stream(filename, pdf_sha, pdf_content)
+    return jsonify(results)
 
 if __name__ == '__main__':
     app.run(port=8080, host='0.0.0.0')

--- a/doc2json/flask/app.py
+++ b/doc2json/flask/app.py
@@ -2,6 +2,7 @@
 Flask app for S2ORC pdf2json utility
 """
 import hashlib
+import requests
 from flask import Flask, request, jsonify, flash, url_for, redirect, render_template, send_file
 from doc2json.grobid2json.process_pdf import process_pdf_stream
 from doc2json.tex2json.process_tex import process_tex_stream

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Flask==1.0.2
 lxml
 python-magic==0.4.18
 latex2mathml==2.16.2
+itsdangerous==2.0.1


### PR DESCRIPTION
When running the flask app with latest `itsdangerous v2.10` getting the error `ImportError: cannot import name 'json' from 'itsdangerous'`

The latest released `itsdangerous` version (2.10) deprecated the JSON API.

`itsdangerous v2.0.1` still supports JSON API.

Source: https://serverfault.com/questions/1094062/error-from-itsdangerous-import-json-as-json-importerror-cannot-import-name-j