### PR TITLE
Fix front tag utils issues caused by tag not found

### DIFF
--- a/doc2json/jats2json/pmc_utils/extract_utils.py
+++ b/doc2json/jats2json/pmc_utils/extract_utils.py
@@ -12,10 +12,11 @@ def extract_fig_blobs(body_tag) -> Dict:
     for fig_tag in body_tag.find_all('fig'):
         fig = fig_tag.extract()
         label = fig.find('label')
-        fig_blobs[fig['id']] = {
-            'label': label and label.text,
-            'caption': fig.find('caption')
-        }
+        if fig.has_attr('id'):
+            fig_blobs[fig['id']] = {
+                'label': label and label.text,
+                'caption': fig.find('caption'),
+            }
     _update_fig_blobs(fig_blobs)
     return fig_blobs
 

--- a/doc2json/jats2json/pmc_utils/front_tag_utils.py
+++ b/doc2json/jats2json/pmc_utils/front_tag_utils.py
@@ -86,7 +86,8 @@ def parse_pubmed_id_tag(front_tag) -> Optional[str]:
 
 
 def parse_pmc_id_tag(front_tag) -> str:
-    return f"PMC{front_tag.find('article-id', {'pub-id-type': 'pmc'}).extract().text}"
+    pmc_tag = front_tag.find('article-id', {'pub-id-type': 'pmc'})
+    return f"PMC{pmc_tag.extract().text}" if pmc_tag else ""
 
 
 def parse_doi_tag(front_tag) -> Optional[str]:

--- a/doc2json/jats2json/pmc_utils/front_tag_utils.py
+++ b/doc2json/jats2json/pmc_utils/front_tag_utils.py
@@ -72,7 +72,8 @@ def parse_journal_name_tag(front_tag) -> str:
     """
     if len(front_tag.find_all('journal-title')) > 1:
         raise Exception('Multiple journal titles?!')
-    return front_tag.find('journal-title').extract().text
+    journal_title_tag = front_tag.find('journal-title')
+    return journal_title_tag.extract().text if journal_title_tag else ""
 
 
 def parse_pubmed_id_tag(front_tag) -> Optional[str]:

--- a/doc2json/jats2json/pmc_utils/front_tag_utils.py
+++ b/doc2json/jats2json/pmc_utils/front_tag_utils.py
@@ -39,6 +39,11 @@ def parse_journal_id_tag(front_tag) -> str:
     for tag in front_tag.find_all('journal-id'):
         c[tag.text] += 1
         tag.decompose()
+
+    # if the counter is empty, the 'journal-id' tag could not be found.
+    if not c:
+        return ""
+
     journal_id, n = c.most_common(1)[0]
     return journal_id
 

--- a/doc2json/jats2json/pmc_utils/front_tag_utils.py
+++ b/doc2json/jats2json/pmc_utils/front_tag_utils.py
@@ -113,7 +113,10 @@ def parse_title_tag(front_tag) -> str:
 
     Want to restrict to `title-group` because sometimes title shows up in <notes> under self-citation
     """
-    title_group = front_tag.find('title-group').extract()
+    search = front_tag.find('title-group')
+    if not search:
+        return ""
+    title_group = search.extract()
     if len(title_group.find_all('article-title')) > 1:
         raise Exception('Multiple article titles?!')
     return title_group.find('article-title').text


### PR DESCRIPTION
Hi! When trying to process several XML JATS files (generated by CERMINE), I found several issues in some functions in [`front_tags_utils.py`](https://github.com/allenai/s2orc-doc2json/blob/main/doc2json/jats2json/pmc_utils/front_tag_utils.py). All the issues were caused because some tag could not be found. I guess that the logic thing if a tag is not found is to return an empty string, and that's what I've implemented. Please let me know if this is correct :)