### PR TITLE
added accurate figure number based on text in the xml file

### DIFF
--- a/doc2json/grobid2json/tei_to_json.py
+++ b/doc2json/grobid2json/tei_to_json.py
@@ -129,14 +129,20 @@ def extract_figures_and_tables_from_tei_xml(sp: BeautifulSoup) -> Dict[str, Dict
                         "text": fig.figDesc.text.strip() if fig.figDesc else fig.head.text.strip() if fig.head else "",
                         "latex": None,
                         "type": "table",
-                        "content": table_to_html(fig.table)
+                        "content": table_to_html(fig.table),
+                        "fig_num": fig.get('xml:id')
                     }
                 else:
+                    if True in [char.isdigit() for char in fig.findNext('head').findNext('label')]:
+                        fig_num = fig.findNext('head').findNext('label').contents[0]
+                    else:
+                        fig_num = None
                     ref_map[normalize_grobid_id(fig.get('xml:id'))] = {
                         "text": fig.figDesc.text.strip() if fig.figDesc else "",
                         "latex": None,
                         "type": "figure",
-                        "content": ""
+                        "content": "",
+                        "fig_num": fig_num
                     }
         except AttributeError:
             continue

--- a/doc2json/s2orc.py
+++ b/doc2json/s2orc.py
@@ -18,7 +18,7 @@ SKIP_KEYS = {
 }
 
 REFERENCE_OUTPUT_KEYS = {
-    'figure': {'text', 'type_str', 'uris', 'num'},
+    'figure': {'text', 'type_str', 'uris', 'num', 'fig_num'},
     'table': {'text', 'type_str', 'content', 'num', 'html'},
     'footnote': {'text', 'type_str', 'num'},
     'section': {'text', 'type_str', 'num', 'parent'},
@@ -62,7 +62,8 @@ class ReferenceEntry:
             html: Optional[str] = None,
             uris: Optional[List[str]] = None,
             num: Optional[str] = None,
-            parent: Optional[str] = None
+            parent: Optional[str] = None,
+            fig_num: Optional[str] = None
     ):
         self.ref_id = ref_id
         self.text = text
@@ -74,6 +75,7 @@ class ReferenceEntry:
         self.uris = uris
         self.num = num
         self.parent = parent
+        self.fig_num = fig_num
 
     def as_json(self):
         keep_keys = REFERENCE_OUTPUT_KEYS.get(self.type_str, None)
@@ -91,7 +93,8 @@ class ReferenceEntry:
                 "html": self.html,
                 "uris": self.uris,
                 "num": self.num,
-                "parent": self.parent
+                "parent": self.parent,
+                "fig_num": self.fig_num
             }
 
 


### PR DESCRIPTION
As I was going through several s2orc json files, I noticed that a majority of the fig ref figure numbers (e.g. "FIGREF1") in the s2orc json files are not accurate. The corresponding s2orc .tei.xml file contains the accurate figure number in the "label" tag. 

These changes extract the figure number from the xml "label" tag and include these as a new field called "fig_num" in the json file.