### PR TITLE
Fix path error in Gorbid setup script and upgrade Gorbid to 0.7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 tests/output/*
 tests/temp/*
 .DS_Store
+
+# ignore output dirs
+temp_dir/
+output_dir/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The current `grobid2json` tool uses Grobid to first process each PDF into XML, t
 
 ### Install Grobid
 
-You will need to have Java installed on your machine. Then, you can install your own version of Grobid and get it running, or you can run the following script:
+You will need to have Java (compatible with Java 11) installed on your machine. Then, you can install your own version of Grobid and get it running, or you can run the following script:
 
 ```console
 bash scripts/setup_grobid.sh
@@ -38,7 +38,7 @@ bash scripts/setup_grobid.sh
 
 Note: before running this script, make sure the paths match your installation path. Else it will fail to install.
 
-This will setup Grobid, currently hard-coded as version 0.6.1. Then run:
+This will setup Grobid, currently hard-coded as version 0.7.3. Then run:
 
 ```console
 bash scripts/run_grobid.sh

--- a/doc2json/grobid2json/grobid/grobid.yaml
+++ b/doc2json/grobid2json/grobid/grobid.yaml
@@ -1,0 +1,272 @@
+# this is the configuration file for the GROBID instance
+
+grobid:
+  # where all the Grobid resources are stored (models, lexicon, native libraries, etc.), normally no need to change
+  grobidHome: "grobid-home"
+
+  # path relative to the grobid-home path (e.g. tmp for grobid-home/tmp) or absolute path (/tmp)
+  temp: "tmp"
+  
+  # normally nothing to change here, path relative to the grobid-home path (e.g. grobid-home/lib)
+  nativelibrary: "lib"
+
+  pdf:
+    pdfalto:
+      # path relative to the grobid-home path (e.g. grobid-home/pdfalto), you don't want to change this normally
+      path: "pdfalto"
+      # security for PDF parsing
+      memoryLimitMb: 6096
+      timeoutSec: 120
+
+    # security relative to the PDF parsing result
+    blocksMax: 200000
+    tokensMax: 1000000
+
+  consolidation:
+    # define the bibliographical data consolidation service to be used, either "crossref" for CrossRef REST API or 
+    # "glutton" for https://github.com/kermitt2/biblio-glutton
+    service: "crossref"
+    #service: "glutton"
+    glutton:
+      url: "https://cloud.science-miner.com/glutton"
+      #url: "http://localhost:8080" 
+    crossref:
+      mailto: 
+      # to use crossref web API, you need normally to use it politely and to indicate an email address here, e.g. 
+      #mailto: "toto@titi.tutu"
+      token:
+      # to use Crossref metadata plus service (available by subscription)
+      #token: "yourmysteriouscrossrefmetadataplusauthorizationtokentobeputhere"
+
+  proxy:
+    # proxy to be used when doing external call to the consolidation service
+    host: 
+    port: 
+
+  # CORS configuration for the GROBID web API service
+  corsAllowedOrigins: "*"
+  corsAllowedMethods: "OPTIONS,GET,PUT,POST,DELETE,HEAD"
+  corsAllowedHeaders: "X-Requested-With,Content-Type,Accept,Origin"
+
+  # the actual implementation for language recognition to be used
+  languageDetectorFactory: "org.grobid.core.lang.impl.CybozuLanguageDetectorFactory"
+
+  # the actual implementation for optional sentence segmentation to be used (PragmaticSegmenter or OpenNLP)
+  #sentenceDetectorFactory: "org.grobid.core.lang.impl.PragmaticSentenceDetectorFactory"
+  sentenceDetectorFactory: "org.grobid.core.lang.impl.OpenNLPSentenceDetectorFactory"
+  
+  # maximum concurrency allowed to GROBID server for processing parallel requests - change it according to your CPU/GPU capacities
+  # for a production server running only GROBID, set the value slightly above the available number of threads of the server
+  # to get best performance and security
+  concurrency: 72
+  # when the pool is full, for queries waiting for the availability of a Grobid engine, this is the maximum time wait to try 
+  # to get an engine (in seconds) - normally never change it
+  poolMaxWait: 1
+
+  delft:
+    # DeLFT global parameters
+    # delft installation path if Deep Learning architectures are used to implement one of the sequence labeling model, 
+    # embeddings are usually compiled as lmdb under delft/data (this paramter is ignored if only featured-engineered CRF are used)
+    install: "../delft"
+    pythonVirtualEnv:
+
+  wapiti:
+    # Wapiti global parameters
+    # number of threads for training the wapiti models (0 to use all available processors)
+    nbThreads: 0
+
+  models:
+    # we configure here how each sequence labeling model should be implemented
+    # for feature-engineered CRF, use "wapiti" and possible training parameters are window, epsilon and nbMaxIterations
+    # for Deep Learning, use "delft" and select the target DL architecture (see DeLFT library), the training 
+    # parameters then depends on this selected DL architecture 
+    
+    - name: "segmentation"
+      # at this time, must always be CRF wapiti, the input sequence size is too large for a Deep Learning implementation
+      engine: "wapiti"
+      #engine: "delft"
+      wapiti:
+        # wapiti training parameters, they will be used at training time only
+        epsilon: 0.0000001
+        window: 50
+        nbMaxIterations: 2000
+      delft:
+        # deep learning parameters
+        architecture: "BidLSTM_CRF_FEATURES"
+        useELMo: false
+        runtime:
+          # parameters used at runtime/prediction
+          max_sequence_length: 3000
+          batch_size: 1
+        training:
+          # parameters used for training
+          max_sequence_length: 3000
+          batch_size: 10
+
+    - name: "fulltext"
+      # at this time, must always be CRF wapiti, the input sequence size is too large for a Deep Learning implementation
+      engine: "wapiti"
+      wapiti:
+        # wapiti training parameters, they will be used at training time only
+        epsilon: 0.0001
+        window: 20
+        nbMaxIterations: 1500
+
+    - name: "header"
+      engine: "wapiti"
+      #engine: "delft"
+      wapiti:
+        # wapiti training parameters, they will be used at training time only  
+        epsilon: 0.000001
+        window: 30
+        nbMaxIterations: 1500
+      delft:
+        # deep learning parameters
+        architecture: "BidLSTM_ChainCRF_FEATURES"
+        #transformer: "allenai/scibert_scivocab_cased"
+        useELMo: false
+        runtime:
+          # parameters used at runtime/prediction
+          #max_sequence_length: 510
+          max_sequence_length: 3000
+          batch_size: 1
+        training:
+          # parameters used for training
+          #max_sequence_length: 510
+          #batch_size: 6
+          max_sequence_length: 3000
+          batch_size: 9
+
+    - name: "reference-segmenter"
+      engine: "wapiti"
+      #engine: "delft"
+      wapiti:
+        # wapiti training parameters, they will be used at training time only
+        epsilon: 0.00001
+        window: 20
+      delft:
+        # deep learning parameters
+        architecture: "BidLSTM_ChainCRF_FEATURES"
+        useELMo: false
+        runtime:
+          # parameters used at runtime/prediction (for this model, use same max_sequence_length as training)
+          max_sequence_length: 3000
+          batch_size: 2
+        training:
+          # parameters used for training
+          max_sequence_length: 3000
+          batch_size: 10
+
+    - name: "name-header"
+      engine: "wapiti"
+      #engine: "delft"
+      delft:
+        # deep learning parameters
+        architecture: "BidLSTM_CRF_FEATURES"
+
+    - name: "name-citation"
+      engine: "wapiti"
+      #engine: "delft"
+      delft:
+        # deep learning parameters
+        architecture: "BidLSTM_CRF_FEATURES"
+
+    - name: "date"
+      engine: "wapiti"
+      #engine: "delft"
+      delft:
+        # deep learning parameters
+        architecture: "BidLSTM_CRF_FEATURES"
+
+    - name: "figure"
+      engine: "wapiti"
+      #engine: "delft"
+      wapiti:
+        # wapiti training parameters, they will be used at training time only
+        epsilon: 0.00001
+        window: 20
+      delft:
+        # deep learning parameters
+        architecture: "BidLSTM_CRF"
+
+    - name: "table"
+      engine: "wapiti"
+      #engine: "delft"
+      wapiti:
+        # wapiti training parameters, they will be used at training time only
+        epsilon: 0.00001
+        window: 20
+      delft:  
+        # deep learning parameters
+        architecture: "BidLSTM_CRF"
+
+    - name: "affiliation-address"
+      engine: "wapiti"
+      #engine: "delft"
+      delft:
+        # deep learning parameters
+        architecture: "BidLSTM_CRF_FEATURES"
+
+    - name: "citation"
+      engine: "wapiti"
+      #engine: "delft"
+      wapiti:
+        # wapiti training parameters, they will be used at training time only
+        epsilon: 0.00001
+        window: 50
+        nbMaxIterations: 3000
+      delft:
+        # deep learning parameters
+        architecture: "BidLSTM_CRF_FEATURES"
+        #architecture: "BERT_CRF"
+        #transformer: "michiyasunaga/LinkBERT-base"
+        useELMo: false
+        runtime:
+          # parameters used at runtime/prediction
+          max_sequence_length: 500
+          batch_size: 30
+        training:
+          # parameters used for training
+          max_sequence_length: 500  
+          batch_size: 50
+
+    - name: "patent-citation"
+      engine: "wapiti"
+      wapiti:
+        # wapiti training parameters, they will be used at training time only
+        epsilon: 0.0001
+        window: 20
+
+  # for **service only**: how to load the models, 
+  # false -> models are loaded when needed (default), avoiding putting in memory useless models but slow down significantly
+  #          the service at first call
+  # true -> all the models are loaded into memory at the server startup, slow the start of the services and models not
+  #         used will take some memory, but server is immediatly warm and ready
+  modelPreload: true
+
+server:
+    type: custom
+    applicationConnectors:
+    - type: http
+      port: 8070
+    adminConnectors:
+    - type: http
+      port: 8071
+    registerDefaultExceptionMappers: false
+
+logging:
+  loggers:
+    org.apache.pdfbox.pdmodel.font.PDSimpleFont: "OFF"
+    org.glassfish.jersey.internal: "OFF"
+  appenders:
+    - type: console
+      level: INFO
+      threshold: WARN
+      timeZone: UTC
+    - type: file
+      currentLogFilename: logs/grobid-service.log
+      threshold: ALL
+      archive: true
+      archivedLogFilenamePattern: logs/grobid-service-%d.log
+      archivedFileCount: 5
+      timeZone: UTC

--- a/scripts/process_multiple_papers.sh
+++ b/scripts/process_multiple_papers.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Path to the directory containing PDF files 
-DIR=/net/nfs/s2-research/joeh/papers/
-
-# Loop through all PDF files and run command on each
-for f in "$DIR"/*.pdf; do
-  python doc2json/grobid2json/process_pdf.py -i "$f" -t temp_dir/ -o output_dir/ 
-done

--- a/scripts/process_multiple_papers.sh
+++ b/scripts/process_multiple_papers.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Path to the directory containing PDF files 
+DIR=/net/nfs/s2-research/joeh/papers/
+
+# Loop through all PDF files and run command on each
+for f in "$DIR"/*.pdf; do
+  python doc2json/grobid2json/process_pdf.py -i "$f" -t temp_dir/ -o output_dir/ 
+done

--- a/scripts/run_grobid.sh
+++ b/scripts/run_grobid.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd $HOME/grobid-0.6.1
+cd $HOME/grobid-0.7.3
 
 ## Start Grobid
 ./gradlew run

--- a/scripts/setup_grobid.sh
+++ b/scripts/setup_grobid.sh
@@ -3,7 +3,7 @@
 # put in your doc2json directory here
 export DOC2JSON_HOME=$HOME/s2orc-doc2json
 
-# Download Grobid
+# # Download Grobid
 cd $HOME
 wget https://github.com/kermitt2/grobid/archive/0.7.3.zip
 unzip 0.7.3.zip
@@ -15,8 +15,7 @@ cd $HOME/grobid-0.7.3
 # increase max.connections to slightly more than number of processes
 # decrease logging level
 # this isn't necessary but is nice to have if you are processing lots of files
-cp $DOC2JSON_HOME/doc2json/grobid/config.yaml $HOME/grobid-0.7.3/grobid-service/config/config.yaml
-cp $DOC2JSON_HOME/doc2json/grobid/grobid.properties $HOME/grobid-0.7.3/grobid-home/config/grobid.properties
+cp $DOC2JSON_HOME/doc2json/grobid2json/grobid/grobid.yaml $HOME/grobid-0.7.3/grobid-home/config/grobid.yaml
 
 ## Start Grobid
 ./gradlew run

--- a/scripts/setup_grobid.sh
+++ b/scripts/setup_grobid.sh
@@ -5,9 +5,9 @@ export PDF2JSON_HOME=$HOME/s2orc-doc2json
 
 # Download Grobid
 cd $HOME
-# wget https://github.com/kermitt2/grobid/archive/0.7.3.zip
-# unzip 0.7.3.zip
-# rm 0.7.3.zip
+wget https://github.com/kermitt2/grobid/archive/0.7.3.zip
+unzip 0.7.3.zip
+rm 0.7.3.zip
 cd $HOME/grobid-0.7.3
 ./gradlew clean install
 

--- a/scripts/setup_grobid.sh
+++ b/scripts/setup_grobid.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# put in your pdf2json directory here
-export PDF2JSON_HOME=$HOME/s2orc-doc2json
+# put in your doc2json directory here
+export DOC2JSON_HOME=$HOME/s2orc-doc2json
 
 # Download Grobid
 cd $HOME
@@ -15,8 +15,8 @@ cd $HOME/grobid-0.7.3
 # increase max.connections to slightly more than number of processes
 # decrease logging level
 # this isn't necessary but is nice to have if you are processing lots of files
-cp $PDF2JSON_HOME/doc2json/grobid/config.yaml $HOME/grobid-0.7.3/grobid-service/config/config.yaml
-cp $PDF2JSON_HOME/doc2json/grobid/grobid.properties $HOME/grobid-0.7.3/grobid-home/config/grobid.properties
+cp $DOC2JSON_HOME/doc2json/grobid/config.yaml $HOME/grobid-0.7.3/grobid-service/config/config.yaml
+cp $DOC2JSON_HOME/doc2json/grobid/grobid.properties $HOME/grobid-0.7.3/grobid-home/config/grobid.properties
 
 ## Start Grobid
 ./gradlew run

--- a/scripts/setup_grobid.sh
+++ b/scripts/setup_grobid.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
 # put in your pdf2json directory here
-export PDF2JSON_HOME=$HOME/git/s2orc-pdf2json
+export PDF2JSON_HOME=$HOME/s2orc-doc2json
 
 # Download Grobid
 cd $HOME
-wget https://github.com/kermitt2/grobid/archive/0.6.1.zip
-unzip 0.6.1.zip
-rm 0.6.1.zip
-cd $HOME/grobid-0.6.1
+# wget https://github.com/kermitt2/grobid/archive/0.7.3.zip
+# unzip 0.7.3.zip
+# rm 0.7.3.zip
+cd $HOME/grobid-0.7.3
 ./gradlew clean install
 
 ## Grobid configurations
 # increase max.connections to slightly more than number of processes
 # decrease logging level
 # this isn't necessary but is nice to have if you are processing lots of files
-cp $PDF2JSON_HOME/pdf2json/grobid/config.yaml $HOME/grobid-0.6.1/grobid-service/config/config.yaml
-cp $PDF2JSON_HOME/pdf2json/grobid/grobid.properties $HOME/grobid-0.6.1/grobid-home/config/grobid.properties
+cp $PDF2JSON_HOME/doc2json/grobid/config.yaml $HOME/grobid-0.7.3/grobid-service/config/config.yaml
+cp $PDF2JSON_HOME/doc2json/grobid/grobid.properties $HOME/grobid-0.7.3/grobid-home/config/grobid.properties
 
 ## Start Grobid
 ./gradlew run


### PR DESCRIPTION
I fixed the path error in `scripts/setup_grobid.sh` where `pdf2json` should be `doc2json`.
I also upgraded gorbid version to `0.7.3`, and create a new config yaml file since the old config files are deprecated.

Successfully run the test command:
```bash
python doc2json/grobid2json/process_pdf.py -i tests/pdf/N18-3011.pdf -t temp_dir/ -o output_dir/
```